### PR TITLE
Decrease window size to use less screen space

### DIFF
--- a/app/open-nsynth/src/main.cpp
+++ b/app/open-nsynth/src/main.cpp
@@ -16,6 +16,6 @@ limitations under the License.
 
 //========================================================================
 int main(){
-	ofSetupOpenGL(1024, 768, OF_WINDOW);
+	ofSetupOpenGL(126, 64, OF_WINDOW);
 	ofRunApp(new ofApp());
 }


### PR DESCRIPTION
Removes large black empty rectangle that draws over CLI + X server (if installed).